### PR TITLE
fix: update JWT regex in appleToken.mjs to match new Apple Music toke…

### DIFF
--- a/backend/lib/appleToken.mjs
+++ b/backend/lib/appleToken.mjs
@@ -18,7 +18,7 @@ export async function getBearerToken() {
   const jsRes = await fetch('https://music.apple.com' + m[0])
   if (!jsRes.ok) throw new Error(`bundle returned ${jsRes.status}`)
   const js = await jsRes.text()
-  const tokenMatch = js.match(/eyJh[A-Za-z0-9_\-\.]+/)
+  const tokenMatch = js.match(/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/)
   if (!tokenMatch) throw new Error('no JWT token found in bundle')
 
   cached = { token: tokenMatch[0], expiresAt: now + TTL_MS }


### PR DESCRIPTION
<img width="1644" height="828" alt="Screenshot From 2026-07-02 11-28-03" src="https://github.com/user-attachments/assets/b1b6567d-3c9c-41f5-8182-1426bddc433e" />

Apple has changed the JWT header format used in their web player's JavaScript bundle.

Previously, the developer token header was `{"alg":"ES256","kid":"..."}`, which base64-encodes to a string starting with `eyJh`. The existing regex `/eyJh[A-Za-z0-9_\-\.]+/` relied on this prefix.

Now, the header is `{"typ":"JWT","alg":"ES256","kid":"..."}`, which base64-encodes to `eyJ0eXAi...`. Since the fourth character is no longer `h`, the old regex fails to match, causing `getBearerToken()` to throw "**no JWT token found in bundle**". This breaks all API calls (search, library sync, downloads, health checks).

The updated regex:

- Matches any base64url string starting with `eyJ` instead of only `eyJh` 
- Enforces proper JWT structure (header.payload.signature — three dot-separated base64url segments) for more precise matching 
- Is resilient to future changes in JWT header field ordering